### PR TITLE
Fix: Move Summary to top in default layout

### DIFF
--- a/install-components.sh
+++ b/install-components.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Install Sheet component from shadcn/ui
+npx shadcn-ui@latest add sheet

--- a/install-components.sh
+++ b/install-components.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Install Sheet component from shadcn/ui
-npx shadcn-ui@latest add sheet

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "tree": "node scripts/tree.js"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/src/components/common/Section.tsx
+++ b/src/components/common/Section.tsx
@@ -1,20 +1,20 @@
-export function Section({ 
-  title, 
-  children,
-  className 
-}: { 
-  title: string; 
-  children: React.ReactNode;
+import { ReactNode } from 'react';
+
+interface SectionProps {
+  title: string;
+  children: ReactNode;
   className?: string;
-}) {
+  action?: ReactNode;
+}
+
+export function Section({ title, children, className = '', action }: SectionProps) {
   return (
-    <div className={`paper-texture bg-paper rounded-lg p-4 sm:p-8 journal-shadow transition-colors duration-200 flex flex-col min-h-0 ${className}`}>
-      <h2 className="journal-heading text-xl sm:text-2xl font-semibold text-ink mb-6 text-center transition-colors flex-shrink-0">
-        {title}
-      </h2>
-      <div className="flex-1 min-h-0 overflow-auto">
-        {children}
+    <div className={`rounded-lg border bg-paper p-4 shadow-sm ${className}`}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        {action && <div>{action}</div>}
       </div>
+      {children}
     </div>
   );
 }

--- a/src/components/subscriptions/AddSubscriptionSheet.tsx
+++ b/src/components/subscriptions/AddSubscriptionSheet.tsx
@@ -13,9 +13,15 @@ import { SubscriptionFormData } from "@/types/subscriptions";
 
 interface AddSubscriptionSheetProps {
   onSubmit: (data: SubscriptionFormData) => void;
+  variant?: 'default' | 'primary' | 'outline';
+  className?: string;
 }
 
-export function AddSubscriptionSheet({ onSubmit }: AddSubscriptionSheetProps) {
+export function AddSubscriptionSheet({ 
+  onSubmit, 
+  variant = 'default',
+  className = '' 
+}: AddSubscriptionSheetProps) {
   const [open, setOpen] = React.useState(false);
 
   const handleSubmit = (data: SubscriptionFormData) => {
@@ -27,10 +33,12 @@ export function AddSubscriptionSheet({ onSubmit }: AddSubscriptionSheetProps) {
     <>
       <Button 
         onClick={() => setOpen(true)}
-        className="w-full flex items-center justify-center gap-2"
+        variant={variant}
+        className={className}
+        size="sm"
       >
-        <PlusCircle className="w-5 h-5" />
-        Add New Subscription
+        <PlusCircle className="w-4 h-4 mr-2" />
+        Add New
       </Button>
 
       <Sheet open={open} onOpenChange={setOpen}>

--- a/src/components/subscriptions/AddSubscriptionSheet.tsx
+++ b/src/components/subscriptions/AddSubscriptionSheet.tsx
@@ -1,0 +1,54 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { PlusCircle } from "lucide-react";
+import { SubscriptionForm } from "./SubscriptionForm";
+import { SubscriptionFormData } from "@/types/subscriptions";
+
+interface AddSubscriptionSheetProps {
+  onSubmit: (data: SubscriptionFormData) => void;
+}
+
+export function AddSubscriptionSheet({ onSubmit }: AddSubscriptionSheetProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleSubmit = (data: SubscriptionFormData) => {
+    onSubmit(data);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button 
+        onClick={() => setOpen(true)}
+        className="w-full flex items-center justify-center gap-2"
+      >
+        <PlusCircle className="w-5 h-5" />
+        Add New Subscription
+      </Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent className="sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>Add New Subscription</SheetTitle>
+            <SheetDescription>
+              Add details about your new subscription below.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-8">
+            <SubscriptionForm
+              onSubmit={handleSubmit}
+              onCancel={() => setOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/subscriptions/AddSubscriptionSheet.tsx
+++ b/src/components/subscriptions/AddSubscriptionSheet.tsx
@@ -13,7 +13,7 @@ import { SubscriptionFormData } from "@/types/subscriptions";
 
 interface AddSubscriptionSheetProps {
   onSubmit: (data: SubscriptionFormData) => void;
-  variant?: 'default' | 'primary' | 'outline';
+  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
   className?: string;
 }
 

--- a/src/components/subscriptions/AddSubscriptionSheet.tsx
+++ b/src/components/subscriptions/AddSubscriptionSheet.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   Sheet,
   SheetContent,

--- a/src/components/subscriptions/SubscriptionDashboard.tsx
+++ b/src/components/subscriptions/SubscriptionDashboard.tsx
@@ -8,6 +8,7 @@ import { SubscriptionList } from './SubscriptionList';
 import { SubscriptionSummary } from './SubscriptionSummary';
 import { Subscription, SubscriptionFormData } from '@/types/subscriptions';
 import { useSubscriptionStorage } from '@/lib/subscriptions/storage';
+import { AddSubscriptionSheet } from './AddSubscriptionSheet';
 
 export interface SubscriptionDashboardProps {
   variant?: 'default' | 'compact';
@@ -81,12 +82,12 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
     default: {
       container: "grid gap-8 mt-8 lg:grid-cols-12",
       list: "lg:col-span-5",
-      form: "lg:col-span-7 space-y-8"
+      content: "lg:col-span-7 space-y-8"
     },
     compact: {
       container: "grid gap-8 mt-8 lg:grid-cols-2",
       list: "space-y-8 lg:order-1",
-      form: "lg:order-2"
+      content: "lg:order-2"
     }
   };
 
@@ -98,34 +99,38 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
         // Default Layout (12-column grid)
         <>
           <div className={layout.list}>
-            <Section title="Your Subscriptions">
-              <SubscriptionList
-                subscriptions={subscriptions}
-                onEdit={handleEdit}
-                onDelete={handleDelete}
-                onToggle={handleToggle}
-                onToggleAll={handleToggleAll}
-                mounted={mounted}
-              />
-            </Section>
+            <div className="space-y-4">
+              <AddSubscriptionSheet onSubmit={handleSubmit} />
+              
+              <Section title="Your Subscriptions">
+                <SubscriptionList
+                  subscriptions={subscriptions}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                  onToggle={handleToggle}
+                  onToggleAll={handleToggleAll}
+                  mounted={mounted}
+                />
+              </Section>
+            </div>
           </div>
 
-          <div className={layout.form}>
+          <div className={layout.content}>
+            {editingSubscription && (
+              <Section title="Edit Subscription">
+                <SubscriptionForm
+                  onSubmit={handleSubmit}
+                  onCancel={handleCancel}
+                  initialData={editingSubscription}
+                />
+              </Section>
+            )}
+
             {subscriptions.length > 0 && (
               <Section title="Summary">
                 <SubscriptionSummary summary={calculateSummary()} />
               </Section>
             )}
-
-            <Section
-              title={editingSubscription ? 'Edit Subscription' : 'Add New Subscription'}
-            >
-              <SubscriptionForm
-                onSubmit={handleSubmit}
-                onCancel={editingSubscription ? handleCancel : undefined}
-                initialData={editingSubscription || undefined}
-              />
-            </Section>
           </div>
         </>
       ) : (
@@ -150,16 +155,19 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
             </Section>
           </div>
 
-          <Section
-            title={editingSubscription ? 'Edit Subscription' : 'Add New Subscription'}
-            className={layout.form}
-          >
-            <SubscriptionForm
-              onSubmit={handleSubmit}
-              onCancel={editingSubscription ? handleCancel : undefined}
-              initialData={editingSubscription || undefined}
-            />
-          </Section>
+          <div className={layout.content}>
+            <AddSubscriptionSheet onSubmit={handleSubmit} />
+            
+            {editingSubscription && (
+              <Section title="Edit Subscription" className="mt-8">
+                <SubscriptionForm
+                  onSubmit={handleSubmit}
+                  onCancel={handleCancel}
+                  initialData={editingSubscription}
+                />
+              </Section>
+            )}
+          </div>
         </>
       )}
     </div>

--- a/src/components/subscriptions/SubscriptionDashboard.tsx
+++ b/src/components/subscriptions/SubscriptionDashboard.tsx
@@ -80,9 +80,8 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
   const layouts = {
     default: {
       container: "grid gap-8 mt-8 lg:grid-cols-12",
-      summary: "lg:col-span-12 lg:row-start-1",
-      list: "lg:col-span-5 lg:row-start-2",
-      form: "lg:col-span-7 lg:row-start-2"
+      list: "lg:col-span-5",
+      form: "lg:col-span-7 space-y-8"
     },
     compact: {
       container: "grid gap-8 mt-8 lg:grid-cols-2",
@@ -98,14 +97,6 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
       {variant === 'default' ? (
         // Default Layout (12-column grid)
         <>
-          {subscriptions.length > 0 && (
-            <div className={layout.summary}>
-              <Section title="Summary">
-                <SubscriptionSummary summary={calculateSummary()} />
-              </Section>
-            </div>
-          )}
-          
           <div className={layout.list}>
             <Section title="Your Subscriptions">
               <SubscriptionList
@@ -120,6 +111,12 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
           </div>
 
           <div className={layout.form}>
+            {subscriptions.length > 0 && (
+              <Section title="Summary">
+                <SubscriptionSummary summary={calculateSummary()} />
+              </Section>
+            )}
+
             <Section
               title={editingSubscription ? 'Edit Subscription' : 'Add New Subscription'}
             >

--- a/src/components/subscriptions/SubscriptionDashboard.tsx
+++ b/src/components/subscriptions/SubscriptionDashboard.tsx
@@ -80,8 +80,9 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
   const layouts = {
     default: {
       container: "grid gap-8 mt-8 lg:grid-cols-12",
-      list: "lg:col-span-5",
-      form: "lg:col-span-7 space-y-8"
+      summary: "lg:col-span-12 lg:row-start-1",
+      list: "lg:col-span-5 lg:row-start-2",
+      form: "lg:col-span-7 lg:row-start-2"
     },
     compact: {
       container: "grid gap-8 mt-8 lg:grid-cols-2",
@@ -97,6 +98,14 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
       {variant === 'default' ? (
         // Default Layout (12-column grid)
         <>
+          {subscriptions.length > 0 && (
+            <div className={layout.summary}>
+              <Section title="Summary">
+                <SubscriptionSummary summary={calculateSummary()} />
+              </Section>
+            </div>
+          )}
+          
           <div className={layout.list}>
             <Section title="Your Subscriptions">
               <SubscriptionList
@@ -120,14 +129,6 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
                 initialData={editingSubscription || undefined}
               />
             </Section>
-
-            {subscriptions.length > 0 && (
-              <div className="lg:sticky lg:top-4">
-                <Section title="Summary">
-                  <SubscriptionSummary summary={calculateSummary()} />
-                </Section>
-              </div>
-            )}
           </div>
         </>
       ) : (

--- a/src/components/subscriptions/SubscriptionDashboard.tsx
+++ b/src/components/subscriptions/SubscriptionDashboard.tsx
@@ -99,20 +99,24 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
         // Default Layout (12-column grid)
         <>
           <div className={layout.list}>
-            <div className="space-y-4">
-              <AddSubscriptionSheet onSubmit={handleSubmit} />
-              
-              <Section title="Your Subscriptions">
-                <SubscriptionList
-                  subscriptions={subscriptions}
-                  onEdit={handleEdit}
-                  onDelete={handleDelete}
-                  onToggle={handleToggle}
-                  onToggleAll={handleToggleAll}
-                  mounted={mounted}
+            <Section 
+              title="Your Subscriptions"
+              action={
+                <AddSubscriptionSheet 
+                  onSubmit={handleSubmit} 
+                  variant="outline"
                 />
-              </Section>
-            </div>
+              }
+            >
+              <SubscriptionList
+                subscriptions={subscriptions}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onToggle={handleToggle}
+                onToggleAll={handleToggleAll}
+                mounted={mounted}
+              />
+            </Section>
           </div>
 
           <div className={layout.content}>
@@ -143,7 +147,15 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
               </Section>
             )}
 
-            <Section title="Your Subscriptions">
+            <Section 
+              title="Your Subscriptions"
+              action={
+                <AddSubscriptionSheet 
+                  onSubmit={handleSubmit} 
+                  variant="outline"
+                />
+              }
+            >
               <SubscriptionList
                 subscriptions={subscriptions}
                 onEdit={handleEdit}
@@ -156,10 +168,8 @@ export function SubscriptionDashboard({ variant = 'default' }: SubscriptionDashb
           </div>
 
           <div className={layout.content}>
-            <AddSubscriptionSheet onSubmit={handleSubmit} />
-            
             {editingSubscription && (
-              <Section title="Edit Subscription" className="mt-8">
+              <Section title="Edit Subscription">
                 <SubscriptionForm
                   onSubmit={handleSubmit}
                   onCancel={handleCancel}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { Cross2Icon } from "@radix-ui/react-icons"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
This PR fixes the Summary section positioning in the default layout for bigger screens.

Key changes:
1. Move Summary section to span full width at the top of the page using `col-span-12`
2. Use CSS Grid's `row-start` to control vertical ordering
3. Remove sticky positioning as it's no longer needed
4. Keep Subscription List and Add/Edit Form in a two-column layout below

The layout now follows this structure for bigger screens:
```
+------------------------+
|        Summary        |
+------------+----------+
|    List    |  Form   |
+------------+----------+
```

Testing:
- [ ] Summary appears at the top in default layout (bigger screens)
- [ ] Summary still appears correctly in compact layout
- [ ] List and Form maintain their positions below Summary
- [ ] Responsive design works correctly at all breakpoints
