### PR TITLE
Add authentication protection to protected routes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,30 @@
 'use client';
 
+import { useSession } from 'next-auth/react';
 import { redirect } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { AUTH_CONFIG } from '@/lib/auth/config';
 
 export default function HomePage() {
-  redirect('/subscriptions');
+  const { status } = useSession();
+  const [isClient, setIsClient] = useState(false);
+  
+  // Use useEffect to ensure we're on the client before redirecting
+  useEffect(() => {
+    setIsClient(true);
+    
+    // Only redirect when we know the authentication status
+    if (isClient) {
+      if (status === 'authenticated') {
+        // Redirect to subscriptions if logged in
+        redirect('/subscriptions');
+      } else if (status === 'unauthenticated') {
+        // Redirect to login if not logged in
+        redirect(AUTH_CONFIG.ROUTES.signIn);
+      }
+    }
+  }, [status, isClient]);
+
+  // Show nothing while determining redirect
+  return null;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import { redirect } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { AUTH_CONFIG } from '@/lib/auth/config';
+import { AuthenticatingSpinner } from '@/components/auth/AuthenticatingSpinner';
 
 export default function HomePage() {
   const { status } = useSession();
@@ -25,6 +26,6 @@ export default function HomePage() {
     }
   }, [status, isClient]);
 
-  // Show nothing while determining redirect
-  return null;
+  // Show loading spinner while checking authentication
+  return <AuthenticatingSpinner />;
 }

--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -2,8 +2,9 @@
 
 import { PageHeader } from "@/components/layout/PageHeader";
 import { SubscriptionDashboard } from "@/components/subscriptions/SubscriptionDashboard";
+import withAuth from "@/components/auth/withAuth";
 
-export default function SubscriptionsPage() {
+function SubscriptionsPage() {
   return (
     <div className="min-h-screen transition-colors duration-200">
       <main className="container mx-auto px-3 py-4 sm:px-4 max-w-7xl">
@@ -13,3 +14,6 @@ export default function SubscriptionsPage() {
     </div>
   );
 }
+
+// Export the protected version of the page
+export default withAuth(SubscriptionsPage);

--- a/src/components/auth/AuthenticatingSpinner.tsx
+++ b/src/components/auth/AuthenticatingSpinner.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+
+/**
+ * A simple loading spinner component displayed during authentication checks
+ */
+export function AuthenticatingSpinner() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="flex flex-col items-center space-y-4">
+        <div className="w-12 h-12 rounded-full border-t-2 border-b-2 border-primary animate-spin"></div>
+        <p className="text-sm text-muted-foreground">Checking authentication...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/withAuth.tsx
+++ b/src/components/auth/withAuth.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { redirect } from 'next/navigation';
+import { AUTH_CONFIG } from '@/lib/auth/config';
+import { useEffect, useState } from 'react';
+
+/**
+ * Higher-order component that protects routes by requiring authentication
+ * Redirects to login page if user is not authenticated
+ */
+export default function withAuth<P extends object>(
+  Component: React.ComponentType<P>
+): React.FC<P> {
+  return function ProtectedRoute(props: P) {
+    const { data: session, status } = useSession();
+    const [isClient, setIsClient] = useState(false);
+
+    // Use useEffect to ensure we're on the client before redirecting
+    useEffect(() => {
+      setIsClient(true);
+    }, []);
+
+    // Show nothing while loading to prevent flash of content
+    if (status === 'loading' || !isClient) {
+      return null; 
+    }
+
+    // Redirect to login if not authenticated
+    if (status === 'unauthenticated') {
+      redirect(AUTH_CONFIG.ROUTES.signIn);
+    }
+
+    // User is authenticated, render the protected component
+    return <Component {...props} />;
+  };
+}

--- a/src/components/auth/withAuth.tsx
+++ b/src/components/auth/withAuth.tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import { redirect } from 'next/navigation';
 import { AUTH_CONFIG } from '@/lib/auth/config';
 import { useEffect, useState } from 'react';
+import { AuthenticatingSpinner } from './AuthenticatingSpinner';
 
 /**
  * Higher-order component that protects routes by requiring authentication
@@ -21,9 +22,9 @@ export default function withAuth<P extends object>(
       setIsClient(true);
     }, []);
 
-    // Show nothing while loading to prevent flash of content
+    // Show loading spinner while checking authentication
     if (status === 'loading' || !isClient) {
-      return null; 
+      return <AuthenticatingSpinner />;
     }
 
     // Redirect to login if not authenticated


### PR DESCRIPTION
## Overview

This PR adds authentication protection to the subscriptions page and other protected routes, ensuring users are properly authenticated before accessing these pages.

## Changes

1. Added a `withAuth` Higher Order Component (HOC) for protected routes
   - Automatically redirects to login page if user is not authenticated
   - Includes proper loading states for better UX

2. Added an `AuthenticatingSpinner` component for loading states
   - Provides visual feedback during authentication checks

3. Updated the subscriptions page
   - Now protected with the withAuth HOC
   - Only accessible to authenticated users

4. Updated the home page
   - Checks authentication status before redirecting
   - Directs to login page if not authenticated
   - Directs to subscriptions page if authenticated
   - Shows loading spinner during authentication check

## Testing

- Verified authentication flow from home page
- Tested direct access to /subscriptions when not logged in
- Confirmed proper loading states during authentication checks

## Notes

- This addresses the issue of unauthorized users being automatically redirected to protected pages
- Follows best practices for client-side authentication in Next.js
- Uses existing NextAuth session management