### PR TITLE
Fix StorageError type definition to include missing error codes

### DIFF
--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -8,7 +8,7 @@ export interface IStorageProvider {
 export class StorageError extends Error {
   constructor(
     message: string,
-    public code: 'storage_unavailable' | 'parse_error' | 'write_error' | 'read_error'
+    public code: 'storage_unavailable' | 'parse_error' | 'write_error' | 'read_error' | 'delete_error' | 'clear_error'
   ) {
     super(message);
     this.name = 'StorageError';


### PR DESCRIPTION
## Overview

This PR fixes a TypeScript error related to the `StorageError` class and its type definitions.

## Issue Fixed

The following TypeScript error was occurring during build:

```
./src/lib/storage/mongodb.ts:128:9
Type error: Argument of type '"delete_error"' is not assignable to parameter of type '"storage_unavailable" | "parse_error" | "write_error" | "read_error"'.
  126 |       throw new StorageError(
  127 |         `Failed to delete data: ${errorMessage}`,
> 128 |         'delete_error'
      |         ^
  129 |       );
  130 |     }
  131 |   }
```

The error also affected the `clear_error` type used elsewhere in the code.

## Changes

Added the missing error types to the `StorageError` class in `src/lib/storage/types.ts`:
- Added `'delete_error'` to the union type
- Added `'clear_error'` to the union type

This ensures that the error types used in the MongoDB storage provider are properly supported by the type system.

## Testing

- Verified that the TypeScript error is resolved during build
- No functional changes, only type definitions were updated

## Impact

This is a minor fix that only affects the TypeScript type system and has no runtime impact. It resolves build errors without changing any functionality.
