### PR TITLE
Improve authentication error messages

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -4,16 +4,33 @@ import { useSearchParams } from 'next/navigation';
 import { AlertCircle } from 'lucide-react';
 import Link from 'next/link';
 
+// Map technical error codes to user-friendly messages
+const getErrorMessage = (errorCode: string | null): string => {
+  if (!errorCode) return 'An error occurred during authentication';
+  
+  const errorMessages: Record<string, string> = {
+    AccessDenied: 'Access denied. Please ensure you have the correct permissions.',
+    Configuration: 'There is a problem with the authentication configuration.',
+    CredentialsSignin: 'Invalid email or password. Please check your credentials and try again.',
+    Default: 'An error occurred during authentication. Please try again.',
+    OAuthSignin: 'Error starting the sign-in process. Please try again.',
+    OAuthCallback: 'Error during the sign-in process. Please try again.',
+    OAuthCreateAccount: 'Error creating an account. Please try again.',
+    EmailCreateAccount: 'Error creating an account. Please try again.',
+    Callback: 'Error during the sign-in process. Please try again.',
+    OAuthAccountNotLinked: 'This email is already associated with another account.',
+    EmailSignin: 'Error sending the sign-in email. Please try again.',
+    SessionRequired: 'Please sign in to access this page.',
+    Verification: 'The verification link was invalid or has expired. Please try again.'
+  };
+
+  return errorMessages[errorCode] || errorMessages.Default;
+};
+
 export default function AuthError() {
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
-
-  let errorMessage = 'An error occurred during authentication';
-  if (error === 'AccessDenied') {
-    errorMessage = 'Access denied. Please ensure you have the correct permissions.';
-  } else if (error === 'Configuration') {
-    errorMessage = 'There is a problem with the authentication configuration.';
-  }
+  const errorMessage = getErrorMessage(error);
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -33,13 +33,39 @@ function ErrorAlert({ message }: { message: string }) {
   );
 }
 
+// Map technical error codes to user-friendly messages
+const getErrorMessage = (errorCode: string | null | undefined): string => {
+  if (!errorCode) return "An unexpected error occurred. Please try again.";
+  
+  const errorMessages: Record<string, string> = {
+    CredentialsSignin: "Invalid email or password. Please check your credentials and try again.",
+    Default: "An error occurred during authentication. Please try again.",
+    OAuthSignin: "Error starting the sign-in process. Please try again.",
+    OAuthCallback: "Error during the sign-in process. Please try again.",
+    OAuthCreateAccount: "Error creating an account. Please try again.",
+    EmailCreateAccount: "Error creating an account. Please try again.",
+    Callback: "Error during the sign-in process. Please try again.",
+    OAuthAccountNotLinked: "This email is already associated with another account.",
+    EmailSignin: "Error sending the sign-in email. Please try again.",
+    SessionRequired: "Please sign in to access this page.",
+    AccessDenied: "Access denied. You do not have permission to access this resource."
+  };
+
+  return errorMessages[errorCode] || errorMessages.Default;
+};
+
 function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") || "/";
+  // Check for error in URL (e.g., redirected from protected page)
+  const urlError = searchParams.get("error");
 
   const [isLoading, setIsLoading] = useState(false);
-  const [errors, setErrors] = useState<FormErrors>({});
+  const [errors, setErrors] = useState<FormErrors>(() => {
+    // Initialize with URL error if present
+    return urlError ? { general: getErrorMessage(urlError) } : {};
+  });
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const validateForm = useCallback(
@@ -88,7 +114,7 @@ function LoginPageContent() {
 
       if (!result?.ok) {
         setErrors({
-          general: result?.error || "Authentication failed",
+          general: getErrorMessage(result?.error),
         });
         return;
       }


### PR DESCRIPTION
## Problem
Currently, when users enter incorrect login credentials, they see a technical error message "CredentialsSignin" which is not user-friendly.

## Solution
This PR improves the user experience by:

1. Adding a mapping function to translate technical error codes into user-friendly messages
2. Updating both the login page and auth error page to use these friendly messages
3. Handling URL error parameters to display appropriate messages

## Changes
- Added a `getErrorMessage` function to map error codes to human-readable messages
- Updated the login page to use this function for authentication errors
- Enhanced the auth error page with more comprehensive error handling
- Added specific message for "CredentialsSignin" error which now displays as "Invalid email or password. Please check your credentials and try again."

## Testing
- I've tested this by attempting to login with invalid credentials and confirming the user-friendly error message is displayed correctly.

## Impact
This change improves the user experience without modifying any core authentication logic, ensuring we don't introduce regression errors.