### PR TITLE
Simplify signout UX to use button state change only

### DIFF
--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -1,29 +1,45 @@
 'use client';
 
+import { useState } from 'react';
 import { signOut } from 'next-auth/react';
-import { LogOut } from 'lucide-react';
+import { LogOut, Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
 export default function LogoutButton() {
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const router = useRouter();
+
   const handleSignOut = async () => {
+    // Immediately show visual feedback
+    setIsSigningOut(true);
+    
     try {
       await signOut({ 
         callbackUrl: '/login',
-        redirect: true
+        redirect: true // Let NextAuth handle the redirect after signout completes
       });
     } catch (error) {
       console.error('Error signing out:', error);
-      window.location.href = '/login';
+      // Fallback redirection in case the signOut function fails
+      router.push('/login');
     }
   };
 
   return (
     <button
       onClick={handleSignOut}
+      disabled={isSigningOut}
+      aria-label="Sign out"
       className="flex items-center gap-2 text-sm text-foreground/70 hover:text-foreground
-        transition-colors duration-200 dark:text-foreground/60 dark:hover:text-foreground"
+        transition-colors duration-200 dark:text-foreground/60 dark:hover:text-foreground
+        disabled:opacity-70 disabled:cursor-not-allowed"
     >
-      <LogOut size={18} strokeWidth={1.5} />
-      <span>Sign Out</span>
+      {isSigningOut ? (
+        <Loader2 size={18} className="animate-spin" />
+      ) : (
+        <LogOut size={18} strokeWidth={1.5} />
+      )}
+      <span>{isSigningOut ? 'Signing out...' : 'Sign Out'}</span>
     </button>
   );
 }

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -32,7 +32,7 @@ export default function LogoutButton() {
       aria-label="Sign out"
       className="flex items-center gap-2 text-sm text-foreground/70 hover:text-foreground
         transition-colors duration-200 dark:text-foreground/60 dark:hover:text-foreground
-        disabled:opacity-70 disabled:cursor-not-allowed"
+        disabled:opacity-70 disabled:cursor-default"
     >
       {isSigningOut ? (
         <Loader2 size={18} className="animate-spin" />


### PR DESCRIPTION
## Problem
Currently, the sign-out process lacks immediate visual feedback, and our previous solution added a button state change but then needlessly redirected to a separate logout page.

## Solution
This simplified PR improves the signout UX by focusing only on immediate button feedback:

1. **Immediate Visual Feedback**: The logout button shows a loading spinner and "Signing out..." text as soon as it's clicked
2. **No Intermediate Page**: Instead of redirecting to a separate logout page, we simply handle the entire sign-out process directly from the button
3. **Clean Process Flow**: The user sees the button change state, and when the sign-out is complete, they are redirected to the login page

## Implementation Details
- Updated `LogoutButton.tsx` to show a loading state immediately after being clicked
- Used the built-in NextAuth redirect functionality to handle navigation after sign-out completes
- Added error handling to ensure users always end up at the login page even if sign-out fails

This approach follows the KISS principle (Keep It Simple, Stupid) by eliminating the unnecessary redirect to a separate sign-out page. It improves the user experience with minimal code changes and maintains the expected security behavior.
